### PR TITLE
Increase maximum time scale for plotted waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+* Increase maximum time scale for plotted waveforms ([#1][pr-1])
+    * Added 10000 ms, 20000 ms, and 40000 ms
+
+[pr-1]: https://github.com/CWRUChielLab/Intan-RHX/pull/1

--- a/Engine/Processing/systemstate.cpp
+++ b/Engine/Processing/systemstate.cpp
@@ -465,6 +465,9 @@ SystemState::SystemState(const AbstractRHXController* controller_, StimStepSize 
     tScale->addItem("1000", "1000 ms", 1000.0);
     tScale->addItem("2000", "2000 ms", 2000.0);
     tScale->addItem("4000", "4000 ms", 4000.0);
+    tScale->addItem("10000", "10000 ms", 10000.0);
+    tScale->addItem("20000", "20000 ms", 20000.0);
+    tScale->addItem("40000", "40000 ms", 40000.0);
     tScale->setValue("2000");
 
     yScaleWide = new DiscreteItemList("WideScaleMicroVolts", globalItems, this);

--- a/GUI/Widgets/multicolumndisplay.cpp
+++ b/GUI/Widgets/multicolumndisplay.cpp
@@ -44,15 +44,19 @@ MultiColumnDisplay::MultiColumnDisplay(ControllerInterface* controllerInterface_
     setLayout(mainLayout);
 
     numRefreshZones.resize(state->tScale->numberOfItems());
-    numRefreshZones[0] = 1;
-    numRefreshZones[1] = 1;
-    numRefreshZones[2] = 1;
-    numRefreshZones[3] = 4;
-    numRefreshZones[4] = 8;
-    numRefreshZones[5] = 16;
-    numRefreshZones[6] = 20;
-    numRefreshZones[7] = 40;
-    numRefreshZones[8] = 80;    // This index should equal state->tScale->numberOfItems() - 1.
+    numRefreshZones[0] = 1;     // 10 ms scale    -> 10 ms refresh
+    numRefreshZones[1] = 1;     // 20 ms scale    -> 20 ms refresh
+    numRefreshZones[2] = 1;     // 40 ms scale    -> 40 ms refresh
+    numRefreshZones[3] = 4;     // 100 ms scale   -> 25 ms refresh
+    numRefreshZones[4] = 8;     // 200 ms scale   -> 25 ms refresh
+    numRefreshZones[5] = 16;    // 400 ms scale   -> 25 ms refresh
+    numRefreshZones[6] = 20;    // 1000 ms scale  -> 50 ms refresh
+    numRefreshZones[7] = 40;    // 2000 ms scale  -> 50 ms refresh
+    numRefreshZones[8] = 80;    // 4000 ms scale  -> 50 ms refresh
+    numRefreshZones[9] = 100;   // 10000 ms scale -> 100 ms refresh
+    numRefreshZones[10] = 200;  // 20000 ms scale -> 100 ms refresh
+    numRefreshZones[11] = 200;  // 40000 ms scale -> 200 ms refresh
+    // Final index should equal state->tScale->numberOfItems() - 1.
 
     state->writeToLog("About to create WaveformDisplayManager");
     waveformManager = new WaveformDisplayManager(state, 100, numRefreshZones[state->tScale->getIndex()]);


### PR DESCRIPTION
Added 10000 ms, 20000 ms, and 40000 ms.

![image](https://user-images.githubusercontent.com/241234/163694664-7f99808f-b0a9-4ebe-9a67-48c967269aca.png)
