### PR TITLE
Increase maximum phase durations in stimulation dialog window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 
 * Increase maximum time scale for plotted waveforms ([#1][pr-1])
-    * Added 10000 ms, 20000 ms, and 40000 ms
+    * Added 10000 ms, 20000 ms, and 40000 ms.
+
+* Increase maximum phase durations in stimulation dialog window ([#2][pr-2])
+    * First and second phase durations were capped at 5 ms each. These were
+      increased to allow for the longest possible pulses permitted by the
+      hardware (~2-3 seconds, depending on sampling period). The sum of the
+      post-trigger delay, the post-stim refractory period, and the total
+      duration of the multiphasic waveform (first and second phases plus
+      interphase delay, depending on the stimulation shape) cannot exceed this
+      maximum pulse duration.
 
 [pr-1]: https://github.com/CWRUChielLab/Intan-RHX/pull/1
+[pr-2]: https://github.com/CWRUChielLab/Intan-RHX/pull/2

--- a/Engine/Processing/controllerinterface.cpp
+++ b/Engine/Processing/controllerinterface.cpp
@@ -1274,6 +1274,27 @@ void ControllerInterface::setStimSequenceParameters(Channel* ampChannel)
         eventChargeRecovOff = 0;
     }
 
+    // Warn if events have exceeded the max time.
+    if (eventStartStim > Never ||
+        eventStimPhase2 > Never ||
+        eventStimPhase3 > Never ||
+        eventEndStim > Never ||
+        eventRepeatStim > Never ||
+        eventEnd > Never ||
+        eventAmpSettleOn > Never ||
+        eventAmpSettleOff > Never ||
+        eventAmpSettleOnRepeat > Never ||
+        eventAmpSettleOffRepeat > Never ||
+        eventChargeRecovOn > Never ||
+        eventChargeRecovOff > Never)
+    {
+        QMessageBox::critical(nullptr, tr("Stimulation Pulse Duration Exceeds Hardware Limitation"),
+                                       tr("WARNING: The selected stimulation parameters define a pulse that is longer "
+                                          "than what the hardware can produce. If you do not reduce the pulse duration, "
+                                          "the hardware is likely to execute the wrong stimulation protocol!"),
+                                       QMessageBox::Ok);
+    }
+
     rhxController->programStimReg(stream, channel, AbstractRHXController::EventAmpSettleOn, eventAmpSettleOn);
     rhxController->programStimReg(stream, channel, AbstractRHXController::EventStartStim, eventStartStim);
     rhxController->programStimReg(stream, channel, AbstractRHXController::EventStimPhase2, eventStimPhase2);

--- a/Engine/Processing/stimparameters.cpp
+++ b/Engine/Processing/stimparameters.cpp
@@ -104,8 +104,8 @@ StimParameters::StimParameters(SingleItemList &hList_, SystemState *state_, Sign
         enableAmpSettle = new BooleanItem("EnableAmpSettle", hList_, state_, true, XMLGroupStimParameters, TypeDependencyStim);
         enableChargeRecovery = new BooleanItem("EnableChargeRecovery", hList_, state_, false, XMLGroupStimParameters, TypeDependencyStim);
 
-        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
-        secondPhaseDuration = new DoubleRangeItem("SecondPhaseDurationMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
+        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 1.0e7, 100.0, XMLGroupStimParameters, TypeDependencyStim);
+        secondPhaseDuration = new DoubleRangeItem("SecondPhaseDurationMicroseconds", hList_, state_, 0.0, 1.0e7, 100.0, XMLGroupStimParameters, TypeDependencyStim);
         interphaseDelay = new DoubleRangeItem("InterphaseDelayMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
         firstPhaseAmplitude = new DoubleRangeItem("FirstPhaseAmplitudeMicroAmps", hList_, state_, 0.0, 2550.0, 0.0, XMLGroupStimParameters, TypeDependencyStim);
         secondPhaseAmplitude = new DoubleRangeItem("SecondPhaseAmplitudeMicroAmps", hList_, state_, 0.0, 2550.0, 0.0, XMLGroupStimParameters, TypeDependencyStim);
@@ -164,8 +164,8 @@ StimParameters::StimParameters(SingleItemList &hList_, SystemState *state_, Sign
 
         enabled = new BooleanItem("StimEnabled", hList_, state_, false, XMLGroupStimParameters, TypeDependencyStim);
 
-        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
-        secondPhaseDuration = new DoubleRangeItem("SecondPhaseDurationMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
+        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 1.0e7, 100.0, XMLGroupStimParameters, TypeDependencyStim);
+        secondPhaseDuration = new DoubleRangeItem("SecondPhaseDurationMicroseconds", hList_, state_, 0.0, 1.0e7, 100.0, XMLGroupStimParameters, TypeDependencyStim);
         interphaseDelay = new DoubleRangeItem("InterphaseDelayMicroseconds", hList_, state_, 0.0, 5000.0, 100.0, XMLGroupStimParameters, TypeDependencyStim);
         firstPhaseAmplitude = new DoubleRangeItem("FirstPhaseAmplitudeVolts", hList_, state_, 0.0, 10.24, 0.0, XMLGroupStimParameters, TypeDependencyStim);
         secondPhaseAmplitude = new DoubleRangeItem("SecondPhaseAmplitudeVolts", hList_, state_, 0.0, 10.24, 0.0, XMLGroupStimParameters, TypeDependencyStim);
@@ -210,7 +210,7 @@ StimParameters::StimParameters(SingleItemList &hList_, SystemState *state_, Sign
 
         enabled = new BooleanItem("StimEnabled", hList_, state_, false, XMLGroupStimParameters, TypeDependencyStim);
 
-        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 100000, 100.0, XMLGroupStimParameters, TypeDependencyStim);
+        firstPhaseDuration = new DoubleRangeItem("FirstPhaseDurationMicroseconds", hList_, state_, 0.0, 1.0e7, 100.0, XMLGroupStimParameters, TypeDependencyStim);
         postTriggerDelay = new DoubleRangeItem("PostTriggerDelayMicroseconds", hList_, state_, 0.0, 500000.0, 0.0, XMLGroupStimParameters, TypeDependencyStim);
         pulseTrainPeriod = new DoubleRangeItem("PulseTrainPeriodMicroseconds", hList_, state_, 0.0, 1000000.0, 10000.0, XMLGroupStimParameters, TypeDependencyStim);
         refractoryPeriod = new DoubleRangeItem("RefractoryPeriodMicroseconds", hList_, state_, 0.0, 1000000.0, 1000.0, XMLGroupStimParameters, TypeDependencyStim);

--- a/GUI/Dialogs/stimparamdialog.cpp
+++ b/GUI/Dialogs/stimparamdialog.cpp
@@ -576,6 +576,14 @@ void StimParamDialog::updateFromState()
 
 void StimParamDialog::accept()
 {
+    if (calculateActualSinglePulseDuration() > maxPulseDuration) {
+        QMessageBox::warning(this, tr("Single pulse duration is too long"),
+                                   tr("The single pulse duration exceeds hardware limitations. "
+                                      "You must reduce the duration before you can save these settings."),
+                                   QMessageBox::Ok);
+        return;
+    }
+
     // Save the values of the parameters from the dialog box into the object.
     parameters->stimShape->setIndex(stimShapeComboBox->currentIndex());
     parameters->stimPolarity->setIndex(stimPolarityComboBox->currentIndex());

--- a/GUI/Dialogs/stimparamdialog.cpp
+++ b/GUI/Dialogs/stimparamdialog.cpp
@@ -773,15 +773,21 @@ void StimParamDialog::constrainRefractoryPeriod()
 // Private slot that constrains pulseTrainPeriod's lowest possible value to the sum of the durations of active phases.
 void StimParamDialog::constrainPulseTrainPeriod()
 {
-    double minimum;
+    pulseTrainPeriodSpinBox->setTrueMinimum(calculateWaveformDuration());
+}
+
+// Private method for calculating the total duration of the waveform.
+double StimParamDialog::calculateWaveformDuration()
+{
+    double waveformDuration;
     if (stimShapeComboBox->currentIndex() == Biphasic) {
-        minimum = firstPhaseDurationSpinBox->getTrueValue() + secondPhaseDurationSpinBox->getTrueValue();
+        waveformDuration = firstPhaseDurationSpinBox->getTrueValue() + secondPhaseDurationSpinBox->getTrueValue();
     } else if (stimShapeComboBox->currentIndex() == BiphasicWithInterphaseDelay) {
-        minimum = firstPhaseDurationSpinBox->getTrueValue() + secondPhaseDurationSpinBox->getTrueValue() + interphaseDelaySpinBox->getTrueValue();
+        waveformDuration = firstPhaseDurationSpinBox->getTrueValue() + secondPhaseDurationSpinBox->getTrueValue() + interphaseDelaySpinBox->getTrueValue();
     } else {
-        minimum = (2.0 * firstPhaseDurationSpinBox->getTrueValue()) + secondPhaseDurationSpinBox->getTrueValue();
+        waveformDuration = (2.0 * firstPhaseDurationSpinBox->getTrueValue()) + secondPhaseDurationSpinBox->getTrueValue();
     }
-    pulseTrainPeriodSpinBox->setTrueMinimum(minimum);
+    return waveformDuration;
 }
 
 void StimParamDialog::roundTimeInputs()

--- a/GUI/Dialogs/stimparamdialog.cpp
+++ b/GUI/Dialogs/stimparamdialog.cpp
@@ -41,6 +41,9 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
     timestep = 1.0e6 / state->sampleRate->getNumericValue();  // time step in microseconds
     currentstep = RHXRegisters::stimStepSizeToDouble(state->getStimStepSizeEnum()) * 1.0e6;  // current step in microamps
 
+    // Maximum duration of a single pulse is hardware limited to timestep * (2^16 - 1).
+    maxPulseDuration = timestep * 65535;
+
     stimFigure = new StimFigure(parameters, this);
 
     QGroupBox* stimWaveFormGroupBox = new QGroupBox(tr("Stimulation Waveform"), this);
@@ -59,12 +62,12 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
 
     firstPhaseDurationLabel = new QLabel(tr("First Phase Duration (D1):"), this);
     firstPhaseDurationSpinBox = new TimeSpinBox(timestep, this);
-    firstPhaseDurationSpinBox->setRange(0, 5000);
+    firstPhaseDurationSpinBox->setRange(0, maxPulseDuration);
     connect(qApp, SIGNAL(focusChanged(QWidget*,QWidget*)), this, SLOT(notifyFocusChanged(QWidget*,QWidget*)));
 
     secondPhaseDurationLabel = new QLabel(tr("Second Phase Duration (D2):"), this);
     secondPhaseDurationSpinBox = new TimeSpinBox(timestep, this);
-    secondPhaseDurationSpinBox->setRange(0, 5000);
+    secondPhaseDurationSpinBox->setRange(0, maxPulseDuration);
 
     interphaseDelayLabel = new QLabel(tr("Interphase Delay (DP):"), this);
     interphaseDelaySpinBox = new TimeSpinBox(timestep, this);

--- a/GUI/Dialogs/stimparamdialog.cpp
+++ b/GUI/Dialogs/stimparamdialog.cpp
@@ -143,6 +143,12 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
     refractoryPeriodSpinBox = new TimeSpinBox(timestep, this);
     refractoryPeriodSpinBox->setRange(0, 1000000);
 
+    // Create Single Pulse Duration widgets.
+    singlePulseDurationGroupBox = new QGroupBox(tr("Single Pulse Duration"));
+    singlePulseDurationGroupBox->setToolTip(tr("Max = 65535 * time step\nActual = delay + waveform duration + refractory period"));
+    maxSinglePulseDurationLabel = new QLabel(tr("Maximum single pulse duration: ") + QString::number(maxPulseDuration / 1000) + " ms");
+    actualSinglePulseDurationLabel = new QLabel(tr("Pulse Duration Placeholder"));
+
     // Create Amp Settle widgets.
     QGroupBox* ampSettleGroupBox = new QGroupBox(tr("Amp Settle"), this);
 
@@ -212,6 +218,13 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
     connect(firstPhaseAmplitudeSpinBox, SIGNAL(editingFinished()), this, SLOT(roundCurrentInputs()));
     connect(secondPhaseAmplitudeSpinBox, SIGNAL(editingFinished()), this, SLOT(roundCurrentInputs()));
     connect(enableStimCheckBox, SIGNAL(toggled(bool)), stimFigure, SLOT(highlightStimTrace(bool)));
+
+    connect(stimShapeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(updateActualSinglePulseDuration()));
+    connect(firstPhaseDurationSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateActualSinglePulseDuration()));
+    connect(secondPhaseDurationSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateActualSinglePulseDuration()));
+    connect(interphaseDelaySpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateActualSinglePulseDuration()));
+    connect(postTriggerDelaySpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateActualSinglePulseDuration()));
+    connect(refractoryPeriodSpinBox, SIGNAL(valueChanged(double)), this, SLOT(updateActualSinglePulseDuration()));
 
     // Connect signals to stimFigure's non-highlight slots.
     connect(stimShapeComboBox, SIGNAL(currentIndexChanged(int)), stimFigure, SLOT(updateStimShape(int)));
@@ -390,6 +403,12 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
     pulseTrainLayout->addLayout(refractoryPeriodRow);
     pulseTrainGroupBox->setLayout(pulseTrainLayout);
 
+    // Single pulse duration widgets' layout
+    QVBoxLayout *singlePulseDurationLayout = new QVBoxLayout;
+    singlePulseDurationLayout->addWidget(maxSinglePulseDurationLabel);
+    singlePulseDurationLayout->addWidget(actualSinglePulseDurationLabel);
+    singlePulseDurationGroupBox->setLayout(singlePulseDurationLayout);
+
     // Amp Settle widgets' layout
     QHBoxLayout *preStimAmpSettleRow = new QHBoxLayout;
     preStimAmpSettleRow->addWidget(preStimAmpSettleLabel);
@@ -437,6 +456,7 @@ StimParamDialog::StimParamDialog(SystemState* state_, Channel* channel_, QWidget
     QVBoxLayout *firstColumn = new QVBoxLayout;
     firstColumn->addWidget(triggerGroupBox);
     firstColumn->addWidget(pulseTrainGroupBox);
+    firstColumn->addWidget(singlePulseDurationGroupBox);
     firstColumn->addStretch();
 
     QVBoxLayout *secondColumn = new QVBoxLayout;
@@ -536,6 +556,9 @@ void StimParamDialog::updateParametersFromState(StimParameters *parameters)
     // Calculate frequency and charge so that the first labels that are displayed correspond to the loaded parameters.
     calculatePulseTrainFrequency();
     calculateCharge();
+
+    // Calculate actual single pulse duration from other parameters and display the value in its label.
+    updateActualSinglePulseDuration();
 }
 
 void StimParamDialog::activate()
@@ -671,6 +694,9 @@ void StimParamDialog::enableWidgets()
     postStimChargeRecovOffLabel->setEnabled(enableStimCheckBox->isChecked() && enableChargeRecoveryCheckBox->isChecked());
     postStimChargeRecovOffSpinBox->setEnabled(enableStimCheckBox->isChecked() && enableChargeRecoveryCheckBox->isChecked());
 
+    // Single Pulse Period
+    singlePulseDurationGroupBox->setEnabled(enableStimCheckBox->isChecked());
+
     // Reset Text for First Phase Labels
     if (stimShapeComboBox->currentIndex() == Biphasic || stimShapeComboBox->currentIndex() == BiphasicWithInterphaseDelay) {
         firstPhaseDurationLabel->setText(tr("First Phase Duration (D1):"));
@@ -791,6 +817,29 @@ double StimParamDialog::calculateWaveformDuration()
         waveformDuration = (2.0 * firstPhaseDurationSpinBox->getTrueValue()) + secondPhaseDurationSpinBox->getTrueValue();
     }
     return waveformDuration;
+}
+
+// Private method for calculating the total duration of the single pulse.
+double StimParamDialog::calculateActualSinglePulseDuration()
+{
+    double totalPulseDuration = postTriggerDelaySpinBox->getTrueValue() + calculateWaveformDuration() + refractoryPeriodSpinBox->getTrueValue();
+    return totalPulseDuration;
+}
+
+// Private slot that calculates the actual single pulse duration and updates its label.
+void StimParamDialog::updateActualSinglePulseDuration()
+{
+    double totalPulseDuration = calculateActualSinglePulseDuration();
+
+    if (totalPulseDuration < 999)
+        actualSinglePulseDurationLabel->setText("Actual single pulse duration: " + QString::number(totalPulseDuration, 'f', 1) + " " + MicroSecondsSymbol);
+    else
+        actualSinglePulseDurationLabel->setText("Actual single pulse duration: " + QString::number(totalPulseDuration/1000, 'f', 3) + " ms");
+
+    if (totalPulseDuration <= maxPulseDuration)
+        actualSinglePulseDurationLabel->setStyleSheet("QLabel {}");
+    else
+        actualSinglePulseDurationLabel->setStyleSheet("QLabel {color: red}");
 }
 
 void StimParamDialog::roundTimeInputs()

--- a/GUI/Dialogs/stimparamdialog.h
+++ b/GUI/Dialogs/stimparamdialog.h
@@ -125,6 +125,7 @@ private:
 
     double timestep;
     double currentstep;
+    double maxPulseDuration;
 
     double calculateWaveformDuration();
 

--- a/GUI/Dialogs/stimparamdialog.h
+++ b/GUI/Dialogs/stimparamdialog.h
@@ -126,6 +126,8 @@ private:
     double timestep;
     double currentstep;
 
+    double calculateWaveformDuration();
+
 private slots:
     void enableWidgets();
     void calculateCharge();

--- a/GUI/Dialogs/stimparamdialog.h
+++ b/GUI/Dialogs/stimparamdialog.h
@@ -123,11 +123,16 @@ private:
     QLabel *postStimChargeRecovOffLabel;
     QCheckBox *enableChargeRecoveryCheckBox;
 
+    QGroupBox *singlePulseDurationGroupBox;
+    QLabel *maxSinglePulseDurationLabel;
+    QLabel *actualSinglePulseDurationLabel;
+
     double timestep;
     double currentstep;
     double maxPulseDuration;
 
     double calculateWaveformDuration();
+    double calculateActualSinglePulseDuration();
 
 private slots:
     void enableWidgets();
@@ -137,6 +142,7 @@ private slots:
     void constrainPostStimChargeRecovery();
     void constrainRefractoryPeriod();
     void constrainPulseTrainPeriod();
+    void updateActualSinglePulseDuration();
     void roundTimeInputs();
     void roundCurrentInputs();
 


### PR DESCRIPTION
Stim phase durations were capped at 5 ms in the StimParamDialog. This PR increases the maximum value these parameters can accept, up to a maximum compatible with hardware limitations. The user is notified if the sum of the durations is too large and is required to reduce the values.

![image](https://user-images.githubusercontent.com/241234/163696174-f02fb09d-41c7-4eb0-a926-2e6a1a26a168.png)
